### PR TITLE
Add re-authentication fix and logging

### DIFF
--- a/src/conf.js
+++ b/src/conf.js
@@ -1,11 +1,16 @@
 // src/conf
 // Set default configuration and provide a method for overriding
+const util  = require('util');
+
+const baseLogger = (response) => {
+  console.log(util.inspect(response, { colors: true, depth: null }));
+}
+
 const conf = {
   Promise: Promise,
+  Logger: baseLogger
 };
 
 module.exports.conf = conf;
 
 module.exports.configure = (newConf) => Object.assign(conf, newConf);
-
-

--- a/src/request.js
+++ b/src/request.js
@@ -95,7 +95,6 @@ const authenticate = () => (
   })
 );
 
-// TODO: check cookie expiration
 const checkAuthentication = () => new conf.Promise((resolve, reject) => {
   if (cookie) { return resolve(true); }
   return resolve(authenticate());
@@ -112,6 +111,7 @@ const request = (opts) => {
 
       // If unauthorized error, attempt to re-authenticate
       if (err.statusCode === 401) {
+        cookie = null;
         return authenticate().then(() => ravelloRequest(opts));
       }
 

--- a/src/request.js
+++ b/src/request.js
@@ -9,6 +9,7 @@ const API_PATH = '/api/v1';
 const DOMAIN   = process.env.RAVELLO_DOMAIN;
 const USERNAME = process.env.RAVELLO_USERNAME;
 const PASSWORD = process.env.RAVELLO_PASSWORD;
+const DEBUG    = process.env.RAVELLO_DEV_MODE_ENABLED;
 
 const baseHeaders = {
   'Content-Type': 'application/json',
@@ -50,12 +51,15 @@ const ravelloRequest = ({ body, headers={}, method, path }) => new conf.Promise(
         if (responseData.length > 0) {
           try {
             responseData = JSON.parse(responseData);
+
+            if (DEBUG) {
+              console.log(`PATH - ${opts.path}`)
+              conf.Logger(responseData);
+            }
           }
           catch(e) {
             console.log('Could not parse responseData:', e);
           }
-
-          console.log(`${opts.path} - ${responseData}`)
         }
 
         if (!res.statusCode.toString().startsWith('2')) {


### PR DESCRIPTION
Checking for expiration in the cookie directly is not possible. If the cached cookie is not set to null before calling /login again an expired one gets used and everything is terrible. 

Also adds a configurable logging option, which defaults to util.inspect with some basic options.