### PR TITLE
Image Waiter + executeVMsAction Path Fix

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -40,3 +40,16 @@ const vmStates = module.exports.vmStates = {
   WAITING_TO_START: 'WAITING_TO_START',
   WAITING_TO_STOP:  'WAITING_TO_STOP',
 };
+
+const loadingStatuses = module.exports.loadingStatuses = {
+  DELETED:         'DELETED',
+  DELETING:        'DELETING',
+  DONE:            'DONE',
+  ERROR:           'ERROR',
+  ERROR_UPLOADING: 'ERROR_UPLOADING',
+  PARSING:         'PARSING',
+  PAUSED:          'PAUSED',
+  SAVING:          'SAVING',
+  UNKNOWN:         'UNKNOWN',
+  UPLOADING:       'UPLOADING',
+};

--- a/src/methods.js
+++ b/src/methods.js
@@ -1001,7 +1001,7 @@ module.exports.getVMVMCURL = {
 
 module.exports.executeVMsAction = {
   method: POST,
-  path:   ({ action, appId, vmId }) => `/applications/${appId}/vms/${vmId}/${action}`,
+  path:   ({ action, appId }) => `/applications/${appId}/vms/${action}`,
 };
 
 module.exports.poweroffVM = {

--- a/src/waiters.js
+++ b/src/waiters.js
@@ -1,8 +1,8 @@
 // src/waiters
 const conf  = require('./conf').conf;
 const request = require('./request');
-const { vmStates } = require('./constants');
-const { getVMState, isApplicationPublished } = require('./methods');
+const { vmStates, loadingStatuses } = require('./constants');
+const { getVMState, getImage, isApplicationPublished } = require('./methods');
 
 const composeMethod = ({ method, path }) => (body) => request({ path, method, body });
 
@@ -15,7 +15,7 @@ const waitFor = ({ method, methodArgs, maxTries=5, retryInterval=15, targetName,
           const attr = targetAttribute ? response[targetAttribute] : response;
 
           if (attr === expectedValue) {
-            return resolve();
+            return resolve(response);
           }
 
           console.log(`${targetName} ${targetId} is in condition ${attr} [ Attempt # ${i} ]`);
@@ -54,5 +54,16 @@ const waitForPublished = module.exports.waitForPublished = (appId) => (
     targetName: 'Application',
     targetAttribute: 'value',
     expectedValue: true,
+  })
+);
+
+const waitForImageAvailable = module.exports.waitForImageAvailable = (imageId) => (
+  waitFor({
+    expectedValue:   loadingStatuses.DONE,
+    method:          getImage,
+    methodArgs:      { imageId },
+    targetAttribute: 'loadingStatus',
+    targetId:        imageId,
+    targetName:      'Image',
   })
 );

--- a/src/waiters.js
+++ b/src/waiters.js
@@ -57,9 +57,9 @@ const waitForPublished = module.exports.waitForPublished = (appId) => (
   })
 );
 
-const waitForImageAvailable = module.exports.waitForImageAvailable = (imageId) => (
+const waitForImageState = module.exports.waitForImageState = (imageId, expectedValue) => (
   waitFor({
-    expectedValue:   loadingStatuses.DONE,
+    expectedValue,
     method:          getImage,
     methodArgs:      { imageId },
     targetAttribute: 'loadingStatus',


### PR DESCRIPTION
* Add constants for `loadingStatus` values
* Add waiter that waits for an image to be in a given state
* Fix `executeVmsAction` path