### PR TITLE
Credentials Configuration

### DIFF
--- a/src/conf.js
+++ b/src/conf.js
@@ -7,10 +7,17 @@ const baseLogger = (response) => {
 }
 
 const conf = {
-  Promise: Promise,
-  Logger: baseLogger
+  Promise:     Promise,
+  Logger:      baseLogger,
+  credentials: {
+    domain:   null,
+    password: null,
+    username: null,
+  },
 };
 
 module.exports.conf = conf;
 
-module.exports.configure = (newConf) => Object.assign(conf, newConf);
+module.exports.configure = (newConf) => {
+  Object.assign(conf, newConf);
+}

--- a/src/request.js
+++ b/src/request.js
@@ -17,9 +17,17 @@ const baseHeaders = {
   Accept: 'application/json',
 };
 
-const makeAuthHeader = ({ domain, username, password }) => ({
-  Authorization: 'Basic: ' + new Buffer(`${domain}/${username}:${password}`).toString('base64'),
-});
+const makeAuthHeader = (credentials) => {
+  if (!credentials || !credentials.domain || !credentials.password || !credentials.username) {
+    throw new Error('Ravello credentials (username, password, and domain) are required to make authentication request.');
+  };
+
+  const { domain, username, password } = credentials;
+
+  return {
+    Authorization: 'Basic: ' + new Buffer(`${domain}/${username}:${password}`).toString('base64'),
+  }
+};
 
 let cookie;
 
@@ -85,17 +93,13 @@ const ravelloRequest = ({ body, headers={}, method, path }) => new conf.Promise(
   req.end();
 });
 
-const authenticate = () => {
-  if (!conf.credentials || !conf.credentials.domain || !conf.credentials.password || !conf.credentials.username) {
-    throw new Error('Ravello credentials (username, password, and domain) are required to make authentication request.');
-  };
-
-  return ravelloRequest({
+const authenticate = () => (
+  ravelloRequest({
     headers: makeAuthHeader(conf.credentials),
     method:  'POST',
     path:    '/login',
   })
-};
+);
 
 const checkAuthentication = () => new conf.Promise((resolve, reject) => {
   if (cookie) { return resolve(true); }

--- a/src/request.js
+++ b/src/request.js
@@ -10,9 +10,6 @@ const hasError = require('./errors').hasError;
 const API_HOST = 'cloud.ravellosystems.com';
 const API_PATH = '/api/v1';
 
-const DOMAIN   = process.env.RAVELLO_DOMAIN;
-const USERNAME = process.env.RAVELLO_USERNAME;
-const PASSWORD = process.env.RAVELLO_PASSWORD;
 const DEBUG    = process.env.RAVELLO_DEV_MODE_ENABLED;
 
 const baseHeaders = {
@@ -20,8 +17,8 @@ const baseHeaders = {
   Accept: 'application/json',
 };
 
-const makeAuthHeader = (domain, user, pass) => ({
-  Authorization: 'Basic: ' + new Buffer(`${domain}/${user}:${pass}`).toString('base64'),
+const makeAuthHeader = ({ domain, username, password }) => ({
+  Authorization: 'Basic: ' + new Buffer(`${domain}/${username}:${password}`).toString('base64'),
 });
 
 let cookie;
@@ -88,13 +85,17 @@ const ravelloRequest = ({ body, headers={}, method, path }) => new conf.Promise(
   req.end();
 });
 
-const authenticate = () => (
-  ravelloRequest({
-    headers: makeAuthHeader(DOMAIN, USERNAME, PASSWORD),
+const authenticate = () => {
+  if (!conf.credentials || !conf.credentials.domain || !conf.credentials.password || !conf.credentials.username) {
+    throw new Error('Ravello credentials (username, password, and domain) are required to make authentication request.');
+  };
+
+  return ravelloRequest({
+    headers: makeAuthHeader(conf.credentials),
     method:  'POST',
     path:    '/login',
   })
-);
+};
 
 const checkAuthentication = () => new conf.Promise((resolve, reject) => {
   if (cookie) { return resolve(true); }

--- a/src/waiters.js
+++ b/src/waiters.js
@@ -18,7 +18,12 @@ const waitFor = ({ method, methodArgs, maxTries=5, retryInterval=15, targetName,
             return resolve(response);
           }
 
-          console.log(`${targetName} ${targetId} is in condition ${attr} [ Attempt # ${i} ]`);
+          conf.Logger({
+            level: 'INFO',
+            type: 'waiter',
+            message: `${targetName} ${targetId} is in condition ${attr} [ Attempt # ${i} ]`
+          });
+
           throw new Error(`Retry #${attempt}`);
         })
         .catch((err) => {


### PR DESCRIPTION
Allows users to provide a `credentials` object to their configuration object. `makeAuthHeader` will throw an error if any of the three values (domain, username, and password) are missing. Augments `conf.configure` so that it doesn't return the result of `Object.assign` (the new configuration object).

Additionally fixes logging for the waiter so that it uses the configured logger instead of `console.log`.