### PR TITLE
Waiter Modifications + Snapshot Waiter Round 2 + Notification Waiter

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -66,3 +66,7 @@ const pricing = module.exports.pricing = {
   GB_VOLUME_STORAGE:    0.0002812,
   COMPUTE_MINIMUM_COST: 0.425,
 }
+
+const notificationEventTypes = module.exports.notificationEventTypes = {
+  VM_FINISHED_SNAPSHOTTING: 'VM_FINISHED_SNAPSHOTTING',
+};

--- a/src/methods.js
+++ b/src/methods.js
@@ -70,6 +70,11 @@ module.exports.getApplication = {
   path:   ({ appId }) => `/applications/${appId}`,
 };
 
+module.exports.getApplicationDeployment = {
+  method: GET,
+  path:   ({ appId }) => `/applications/${appId};deployment`,
+};
+
 module.exports.getApplicationBillingDetail = {
   method: GET,
   path:   ({ appId }) => `/applications/${appId}/billing`,
@@ -633,6 +638,11 @@ module.exports.updateNetworkInterface = {
 module.exports.searchNotifications = {
   method: POST,
   path:   '/notifications/search',
+};
+
+module.exports.pageNotifications = {
+  method: POST,
+  path:   '/notifications/page',
 };
 
 // Organizations

--- a/src/waiters.js
+++ b/src/waiters.js
@@ -2,7 +2,7 @@
 const conf  = require('./conf').conf;
 const request = require('./request');
 const { vmStates, loadingStatuses } = require('./constants');
-const { getVM, getVMState, getImage, isApplicationPublished } = require('./methods');
+const { getVMDeployment, getVMState, getImage, isApplicationPublished, pageNotifications } = require('./methods');
 
 const invalidResourceStates = {
   [ vmStates.STARTED ]: vmStates.STOPPED,
@@ -11,34 +11,40 @@ const invalidResourceStates = {
 
 const composeMethod = ({ method, path }) => (body) => request({ path, method, body });
 
-const waitFor = ({ method, methodArgs, maxTries=5, retryInterval=15, targetName, targetId, targetAttribute, expectedValue, failureValue }) => {
+const waitFor = ({ expectedValue, failureValue, maxTries=5, method, methodArgs, retryInterval=15, targetId, targetName, targetValue }) => {
   return new conf.Promise((resolve, reject) => {
     const retry = (i) => (
       composeMethod(method)(methodArgs).then((response) => {
-        const attr = targetAttribute ? response[targetAttribute] : response;
+        const value = targetValue ? targetValue(response) : response;
 
-        if (attr === expectedValue) {
+        if (value === expectedValue) {
+          conf.Logger({
+            level: 'INFO',
+            type: 'waiter',
+            message: `${targetName} ${targetId} is in expected state ${expectedValue}.`
+          });
+
           return resolve(response);
         }
 
-        if (attr === failureValue) {
+        if (failureValue && value === failureValue) {
           let error = new Error('Expected failure value reached.');
           error.code = 'ExpectedFailure';
           throw error;
         }
 
         // If the resource won't ever reach the expected state, throw an error
-        if (invalidResourceStates[expectedValue] && attr === invalidResourceStates[expectedValue]) {
-          const err = new Error(`The resource is not in a valid state to reach ${expectedValue}. Current state: ${attr}`);
+        if (invalidResourceStates[value] && value === invalidResourceStates[value]) {
+          const err = new Error(`The resource is not in a valid state to reach ${expectedValue}. Current state: ${value}`);
           err.code = 'ResourceInvalidStateError';
-          err.state = attr;
+          err.state = value;
           throw err;
         }
 
         conf.Logger({
           level: 'INFO',
           type: 'waiter',
-          message: `${targetName} ${targetId} is in condition ${attr}, waiting for condition ${expectedValue} [ Attempt # ${i} ]`
+          message: `${targetName} ${targetId} is in condition ${value}, waiting for condition ${expectedValue} [ Attempt # ${i} ]`
         });
 
         throw new Error(`Retry #${i}`);
@@ -71,45 +77,102 @@ const waitForVMState = module.exports.waitForVMState = (appId, vmId, expectedVal
   waitFor({
     expectedValue,
     failureValue: vmStates.ERROR,
-    method:     getVMState,
-    methodArgs: { appId, vmId },
-    maxTries:   120,
-    targetId:   vmId,
-    targetName: 'VM',
+    maxTries:     120,
+    method:       getVMState,
+    methodArgs:   { appId, vmId },
+    targetId:     vmId,
+    targetName:   'VM',
   })
 );
 
 const waitForSnapshotState = module.exports.waitForSnapshotState = (appId, vmId, expectedValue) => (
   waitFor({
     expectedValue,
-    method:          getVM,
-    methodArgs:      { appId, vmId },
-    maxTries:        120,
-    targetId:        vmId,
-    targetName:      'Snapshot',
-    targetAttribute: 'loadingStatus',
+    maxTries:    120,
+    method:      getVMDeployment,
+    methodArgs:  { appId, vmId },
+    targetId:    vmId,
+    targetName:  'Snapshot',
+    targetValue: (response) => {
+      // If any status isn't the expected value, consider it the target value
+      const vmStatus = response.loadingStatus;
+      if (vmStatus !== expectedValue) { return vmStatus; }
+
+      const diskStatus = response.hardDrives.reduce((acc, disk) => {
+        // Hard drives do not always have a loadingStatus attr
+        if (disk.loadingStatus && disk.loadingStatus !== expectedValue) { acc = disk.loadingStatus; }
+        return acc;
+      }, expectedValue);
+
+
+      if (diskStatus !== expectedValue) { return diskStatus; }
+
+      return expectedValue;
+
+    }
   })
 );
 
 const waitForPublished = module.exports.waitForPublished = (appId) => (
   waitFor({
-    method:     isApplicationPublished,
-    methodArgs: { appId },
-    targetId:   appId,
-    targetName: 'Application',
-    targetAttribute: 'value',
     expectedValue: true,
+    method:        isApplicationPublished,
+    methodArgs:    { appId },
+    targetId:      appId,
+    targetName:    'Application',
+    targetValue:   (res) => res.value,
   })
 );
 
 const waitForImageState = module.exports.waitForImageState = (imageId, expectedValue) => (
   waitFor({
     expectedValue,
-    method:          getImage,
-    methodArgs:      { imageId },
-    maxTries:        120,
-    targetAttribute: 'loadingStatus',
-    targetId:        imageId,
-    targetName:      'Image',
+    maxTries:    120,
+    method:      getImage,
+    methodArgs:  { imageId },
+    targetId:    imageId,
+    targetName:  'Image',
+    targetValue: (res) => res.loadingStatus,
+  })
+);
+
+const waitForNotification = module.exports.waitForNotification = (appId, targetId, eventType, startTime) => (
+  waitFor({
+    expectedValue: eventType,
+    maxTries:      120,
+    method:        pageNotifications,
+    methodArgs:    {
+      paging: {
+        startRecord: 0,
+        pageSize:    100,
+      },
+
+      sorting: {
+        sortOrder: 'desc',
+        propertyName: 'eventTimeStamp',
+      },
+
+      filter: {
+        criteria: {
+          id: 0,
+          type: 'COMPLEX',
+          operator: 'And',
+          criteria: [
+            { id: 0, type: 'SIMPLE', index: 1, operator: 'Equals', propertyName: 'appId', operand: appId },
+            { type: 'SIMPLE', index: 2, operator: 'Equals', propertyName: 'eventType', operand: eventType },
+            { type: 'SIMPLE', index: 3, operator: 'GreaterThan', propertyName: 'eventTimeStamp', operand: new Date(startTime).valueOf() },
+          ],
+        },
+      },
+    },
+    targetId:    targetId,
+    targetName:  'Entity',
+    targetValue: (res) => {
+      const matchingNotifications = res.content.filter((n) => n.eventProperties.find((e) => e.value === targetId) !== undefined);
+
+      if (matchingNotifications.length) { return eventType; }
+
+      return false;
+    },
   })
 );


### PR DESCRIPTION
This modifies the waiter to accept a `targetValue` function instead of `targetAttribute`, to allow for more complicated examination of results.

* `waitForSnapshotState` now calls the correct method and checks hard drive snapshot loading states in addition to the base VM loading state
* New methods: `getApplicationDeployment` and `pageNotifications`, the latter of which is not documented in Ravello's API, but used to search logs in their application log viewer.
* New waiter: `waitForNotification` waits for a notification to be emitted of a given type for a given application ID/entity ID.