### PR TITLE
Loose Equality

### DIFF
--- a/src/waiters.js
+++ b/src/waiters.js
@@ -168,7 +168,7 @@ const waitForNotification = module.exports.waitForNotification = (appId, targetI
     targetId:    targetId,
     targetName:  'Entity',
     targetValue: (res) => {
-      const matchingNotifications = res.content.filter((n) => n.eventProperties.find((e) => e.value === targetId) !== undefined);
+      const matchingNotifications = res.content.filter((n) => n.eventProperties.find((e) => e.value == targetId) !== undefined);
 
       if (matchingNotifications.length) { return eventType; }
 


### PR DESCRIPTION
Ravello VM IDs can sometimes be numbers, and are sometimes strings. We shouldn't enforce type equality here.